### PR TITLE
use readable-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ emits 'stalled' once everything is written
 
 */
 var inherits = require('inherits')
-var stream = require('stream')
+var stream = require('readable-stream')
 
 module.exports = RangeSliceStream
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "John Hiesey",
   "license": "MIT",
   "dependencies": {
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "readable-stream": "^2.0.5"
   }
 }


### PR DESCRIPTION
Per https://r.va.gg/2014/06/why-i-dont-use-nodes-core-stream-module.html

This makes all the videostream deps consistently use readable-stream.
