### PR TITLE
Update readable-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,14 @@ Extract a bunch of ranges from a stream to construct a new stream
 ## Usage
 
 ``` js
-var RangeSliceStream = require('range-slice-stream')
+const RangeSliceStream = require('range-slice-stream')
 
-var slicer = new RangeSliceStream()
+const slicer = new RangeSliceStream()
 slicer.end('abcdefghijklmnop')
 
-var out = slicer.slice([
-{
-	start: 1,
-	end: 3
-},
-{
-	start: 6,
-	end: 9
-}
+const out = slicer.slice([
+  { start: 1, end: 3 },
+  { start: 6, end: 9 }
 ])
 
 out.pipe(process.stdout)

--- a/index.js
+++ b/index.js
@@ -5,121 +5,111 @@ call .get(length) or .discard(length) to get a stream (relative to the last end)
 
 emits 'stalled' once everything is written
 
-
 */
-var inherits = require('inherits')
-var stream = require('readable-stream')
+const { Writable, PassThrough } = require('readable-stream')
+
+class RangeSliceStream extends Writable {
+  constructor (offset, opts = {}) {
+    super(opts)
+
+    this.destroyed = false
+    this._queue = []
+    this._position = offset || 0
+    this._cb = null
+    this._buffer = null
+    this._out = null
+  }
+
+  _write (chunk, encoding, cb) {
+    let drained = true
+
+    while (true) {
+      if (this.destroyed) {
+        return
+      }
+
+      // Wait for more queue entries
+      if (this._queue.length === 0) {
+        this._buffer = chunk
+        this._cb = cb
+        return
+      }
+
+      this._buffer = null
+      var currRange = this._queue[0]
+      // Relative to the start of chunk, what data do we need?
+      const writeStart = Math.max(currRange.start - this._position, 0)
+      const writeEnd = currRange.end - this._position
+
+      // Check if we need to throw it all away
+      if (writeStart >= chunk.length) {
+        this._position += chunk.length
+        return cb(null)
+      }
+
+      // Check if we need to use it all
+      let toWrite
+      if (writeEnd > chunk.length) {
+        this._position += chunk.length
+        if (writeStart === 0) {
+          toWrite = chunk
+        } else {
+          toWrite = chunk.slice(writeStart)
+        }
+        drained = currRange.stream.write(toWrite) && drained
+        break
+      }
+
+      this._position += writeEnd
+
+      toWrite = (writeStart === 0 && writeEnd === chunk.length)
+        ? chunk
+        : chunk.slice(writeStart, writeEnd)
+
+      drained = currRange.stream.write(toWrite) && drained
+      if (currRange.last) {
+        currRange.stream.end()
+      }
+      chunk = chunk.slice(writeEnd)
+      this._queue.shift()
+    }
+
+    if (drained) {
+      cb(null)
+    } else {
+      currRange.stream.once('drain', cb.bind(null, null))
+    }
+  }
+
+  slice (ranges) {
+    if (this.destroyed) return null
+
+    if (!Array.isArray(ranges)) ranges = [ranges]
+
+    const str = new PassThrough()
+
+    ranges.forEach((range, i) => {
+      this._queue.push({
+        start: range.start,
+        end: range.end,
+        stream: str,
+        last: i === ranges.length - 1
+      })
+    })
+
+    if (this._buffer) {
+      this._write(this._buffer, null, this._cb)
+    }
+
+    return str
+  }
+
+  destroy (err) {
+    if (this.destroyed) return
+    this.destroyed = true
+
+    if (err) this.emit('error', err)
+  }
+}
 
 module.exports = RangeSliceStream
-
-inherits(RangeSliceStream, stream.Writable)
-
-function RangeSliceStream (offset, opts) {
-	var self = this
-	if (!(self instanceof RangeSliceStream)) return new RangeSliceStream(offset)
-	stream.Writable.call(self, opts)
-
-	self.destroyed = false
-	self._queue = []
-	self._position = offset || 0
-	self._cb = null
-	self._buffer = null
-	self._out = null
-}
-
-RangeSliceStream.prototype._write = function (chunk, encoding, cb) {
-	var self = this
-
-	var drained = true
-
-	while (true) {
-		if (self.destroyed) {
-			return
-		}
-
-		// Wait for more queue entries
-		if (self._queue.length === 0) {
-			self._buffer = chunk
-			self._cb = cb
-			return
-		}
-
-		self._buffer = null
-		var currRange = self._queue[0]
-		// Relative to the start of chunk, what data do we need?
-		var writeStart = Math.max(currRange.start - self._position, 0)
-		var writeEnd = currRange.end - self._position
-
-		// Check if we need to throw it all away
-		if (writeStart >= chunk.length) {
-			self._position += chunk.length
-			return cb(null)
-		}
-
-		// Check if we need to use it all
-		var toWrite
-		if (writeEnd > chunk.length) {
-			self._position += chunk.length
-			if (writeStart === 0) {
-				toWrite = chunk
-			} else {
-				toWrite = chunk.slice(writeStart)
-			}
-			drained = currRange.stream.write(toWrite) && drained
-			break
-		}
-
-		self._position += writeEnd
-		if (writeStart === 0 && writeEnd === chunk.length) {
-			toWrite = chunk
-		} else {
-			toWrite = chunk.slice(writeStart, writeEnd)
-		}
-		drained = currRange.stream.write(toWrite) && drained
-		if (currRange.last) {
-			currRange.stream.end()
-		}
-		chunk = chunk.slice(writeEnd)
-		self._queue.shift()
-	}
-
-	if (drained) {
-		cb(null)
-	} else {
-		currRange.stream.once('drain', cb.bind(null, null))
-	}
-}
-
-RangeSliceStream.prototype.slice = function (ranges) {
-	var self = this
-
-	if (self.destroyed) return null
-
-	if (!(ranges instanceof Array)) {
-		ranges = [ranges]
-	}
-
-	var str = new stream.PassThrough()
-
-	ranges.forEach(function (range, i) {
-		self._queue.push({
-			start: range.start,
-			end: range.end,
-			stream: str,
-			last: i === (ranges.length - 1)
-		})
-	})
-	if (self._buffer) {
-		self._write(self._buffer, null, self._cb)
-	}
-
-	return str
-}
-
-RangeSliceStream.prototype.destroy = function (err) {
-	var self = this
-	if (self.destroyed) return
-	self.destroyed = true
-
-	if (err) self.emit('error', err)
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "range-slice-stream",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Get slices of a stream",
   "main": "index.js",
   "repository": {
@@ -19,7 +19,6 @@
   "author": "John Hiesey",
   "license": "MIT",
   "dependencies": {
-    "inherits": "^2.0.1",
-    "readable-stream": "^2.0.5"
+    "readable-stream": "^3.0.2"
   }
 }


### PR DESCRIPTION
Hi, I don't directly use `range-slice-stream` but one of your dependency is outdated (readable-stream v2)

I have another package that uses readable-stream v3 and your v2 is making lots of duplicated code

I updated your code to use es6 that is compatible with latest node LTS ( node v6 )
therefore i removed inherits and replaced it with class extends

And now you can't call `RangeSliceStream()` without `new` And readable-stream made a major update so i thought a new major version where in place here to